### PR TITLE
Basic support for array like property access

### DIFF
--- a/lib/jazz/ast.js
+++ b/lib/jazz/ast.js
@@ -187,6 +187,17 @@ SyncCall.prototype.toString = function() {
   return "SyncCall(" + (this.id ? this.id.toString() : 'undefined') + ", " + _arrayToString(this.args) + ")";
 }
 
+function GetArr(expr, index) {
+  this.expr = expr;
+  this.index = index;
+  this.value = this;
+  return this;
+}
+
+GetArr.prototype.toString = function() {
+  return "GetArr(" + this.expr.toString() + ", " + this.index.toString() + ")";
+}
+
 exports.Suite  = Suite;
 exports.Ident  = Ident;
 exports.IfStmt = IfStmt;
@@ -205,3 +216,4 @@ exports.Not     = Not;
 exports.Empty   = Empty;
 exports.BinOp   = BinOp;
 exports.AST     = AST;
+exports.GetArr = GetArr;

--- a/lib/jazz/compiler.js
+++ b/lib/jazz/compiler.js
@@ -158,6 +158,9 @@ Compiler_JS.prototype._compileStatement = function(stmt) {
   else if (stmt.constructor == ast.Suite) {
     code += this._compileSuite(stmt);
   }
+  else if (stmt.constructor == ast.GetArr) {
+    code += this._compileEcho(stmt);
+  }
   else {
     throw new CompileError("!FIXME!", stmt.row, stmt.col, "unknown statement type: " + stmt.type);
   }
@@ -310,6 +313,9 @@ Compiler_JS.prototype._compileExpr = function(expr) {
     }
     code += ')';
     return code;
+  }
+  else if (expr.constructor == ast.GetArr) {
+    return "(" + this._compileExpr(expr.expr) + ")[" + this._compileExpr(expr.index) + "]";
   }
   else {
     throw new CompileError("!FIXME!", expr.row, expr.col, "unknown expression type: " + JSON.stringify(expr));

--- a/lib/jazz/parser.js
+++ b/lib/jazz/parser.js
@@ -166,6 +166,11 @@ Parser.prototype._parseSimpleExpr = function() {
     this.next();
     result = new ast.Empty(this._parseSimpleExpr());
   }
+  else if (this.current().type == '[') {
+    this.next();
+    result = this._parseSimpleExpr();
+    this._expect(']');
+  }
   else {
     this._syntaxError(
       this.current(),
@@ -239,6 +244,16 @@ Parser.prototype._parseSuite = function() {
           body.push(this._parseForEach());
           break;
         }
+      case '[':
+        {
+          var index = this._parseSimpleExpr();
+          if (body.length == 0) {
+              this._syntaxError(this.current(), "Incorrect place of array brackets");
+          }
+          //wrap last result for array access
+          body[body.length - 1] = new ast.GetArr(body[body.length - 1], index);
+          break;
+        }
       default:
         more = false;
     }
@@ -278,7 +293,14 @@ Parser.prototype._parseEchoExpr = function() {
     var args = this._parseArgumentList();
     this._expect(')');
     return new ast.Call(result, args);
-  } else {
+  }
+  else if (this.current().type == '[') {
+    this.next();
+    var index = this._parseSimpleExpr();
+    this._expect(']');
+    return new ast.GetArr(result, index);
+  }
+  else {
     return new ast.Echo(this._parseGetAttrList(result));
   }
 }

--- a/lib/jazz/scanner.js
+++ b/lib/jazz/scanner.js
@@ -266,6 +266,16 @@ Scanner.prototype._codeState = function() {
       step();
       break;
     }
+    else if (s[i] == '[') {
+      result = this._makeToken('[');
+      step();
+      break;
+    }
+    else if (s[i] == ']') {
+      result = this._makeToken(']');
+      step();
+      break;
+    }
     else if (s[i] == ',') {
       result = this._makeToken(',');
       step();

--- a/test/all.js
+++ b/test/all.js
@@ -169,7 +169,19 @@ var testCases = [
   ["{if @blah('a', 'b') eq 'AB'}HI SIR{end}",
     [{blah: function(something, somethings) { return something.toUpperCase() + somethings.toUpperCase(); } }, "HI SIR"]],
   ["{@foo()}",
-    [{foo: function() { return "Hey!"; }}, "Hey!"]]
+    [{foo: function() { return "Hey!"; }}, "Hey!"]],
+  ["{array[0]}",
+    [{array : ["one"]}, "one"]],
+  ["{obj.array[0]}",
+    [{obj : {array : ["one"]}}, "one"]],
+  ["{array[obj.prop]}",
+    [{array : ["one", "two"], obj : {"prop" : 1}}, "two"]],
+  ["{array[0][1]}",
+    [{array : [["one", ["two"]]]}, "two"]],
+  ["{array['text prop']}",
+    [{array : {"text prop" : "two"}}, "two"]]
+  /*["{array[obj.prop[1]]}", //todo currently nested array brackets not supported by the parser
+    [{array : ["one", "two"], obj : {"prop" : [1, 0]}}, "two"]]*/
 ];
 
 testCases.forEach(function(testCase) {


### PR DESCRIPTION
Examples:
  {obj.array[0]},
  {array[obj.prop]}
  {array[0][1]}
  {array['text prop']}

Currently, nested array brackets unsupported: {array[obj.prop[1]]}
