### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/lib/jazz/compiler.js
+++ b/lib/jazz/compiler.js
@@ -251,6 +251,7 @@ class CompilerJS {
 
     if (expr.constructor === ast.Str) {
       return `"${expr.value
+        .replace(/\\/g, "\\\\")
         .replace(/\r/g, "\\r")
         .replace(/\n/g, "\\n")
         .replace(/\t/g, "\\t")


### PR DESCRIPTION
Potential fix for [https://github.com/cliffano/jazz/security/code-scanning/2](https://github.com/cliffano/jazz/security/code-scanning/2)

General fix: when constructing a JavaScript string literal from raw text, escape backslashes first, then escape control characters and quotes globally.

Best minimal fix in `lib/jazz/compiler.js` is to update the `ast.Str` handling block in `_compileExpr` (lines 253–257 region) so it includes `.replace(/\\/g, "\\\\")` before the existing replacements. This preserves existing behavior while making escaping complete for backslashes.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
